### PR TITLE
Omit feed coordinates from logs

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -174,4 +174,4 @@ The `ExternalGTFSAPI` class extends `MobilityAPI` to handle GTFS files not in th
 - Versioning support with automatic cleanup of old datasets
 - All base class methods (list, delete, etc.) work with external datasets
 
-For more examples, see [examples/external_gtfs_example.py](examples/external_gtfs_example.py). 
+For more examples, see the [external GTFS example on GitHub](https://github.com/bdamokos/mobility-db-api/blob/main/docs/examples/external_gtfs_example.py).

--- a/src/mobility_db_api/api.py
+++ b/src/mobility_db_api/api.py
@@ -267,7 +267,7 @@ class MobilityAPI:
         except IOError as e:
             self.logger.error(f"Error saving metadata: {str(e)}")
 
-    def reload_metadata(self, force: bool = False):
+    def reload_metadata(self, force: bool = False) -> bool:
         """
         Reload metadata from file if it has been modified or if forced.
 
@@ -397,8 +397,9 @@ class MobilityAPI:
             >>> info = api.get_provider_by_id("mdb-123")
             >>> if info:
             ...     print(f"Provider: {info['provider']}")
-            ...     if 'downloaded_dataset' in info:
-            ...         print(f"Downloaded: {info['downloaded_dataset']['download_path']}")
+            ...     downloaded = info.get("downloaded_dataset")
+            ...     if downloaded:
+            ...         print(f"Downloaded: {downloaded.get('download_path')}")
         """
         return self.get_provider_info(provider_id=provider_id)
 

--- a/src/mobility_db_api/api.py
+++ b/src/mobility_db_api/api.py
@@ -829,7 +829,7 @@ class MobilityAPI:
                     min_lon = bounding_box.get("minimum_longitude")
                     max_lon = bounding_box.get("maximum_longitude")
                     self.logger.info(
-                        f"Using bounding box from API/CSV: ({min_lat}, {min_lon}) to ({max_lat}, {max_lon})"
+                        "Using bounding box supplied by API/CSV"
                     )
 
             # Calculate bounding box from stops.txt if needed or forced

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -284,6 +284,70 @@ def test_metadata_tracking(monkeypatch):
         if data_dir.exists():
             shutil.rmtree(data_dir)
 
+
+def test_api_bounding_box_values_are_not_logged(monkeypatch, tmp_path):
+    """Keep public feed bounds in metadata without copying them into logs."""
+    provider_url = "https://api.mobilitydatabase.org/v1/gtfs_feeds/test-provider"
+    dataset_url = "https://downloads.example.test/dataset.zip"
+    bounding_box = {
+        "minimum_latitude": 47.123456,
+        "maximum_latitude": 47.654321,
+        "minimum_longitude": 19.123456,
+        "maximum_longitude": 19.654321,
+    }
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as zip_file:
+        zip_file.writestr("stops.txt", "stop_id,stop_name\n1,Test Stop")
+    zip_content = zip_buffer.getvalue()
+
+    def mock_get(url, **kwargs):
+        response = requests.Response()
+        response.status_code = 200
+        if url == provider_url:
+            response._content = json.dumps(
+                {
+                    "provider": "Test Provider",
+                    "latest_dataset": {
+                        "id": "test-dataset",
+                        "hosted_url": dataset_url,
+                        "bounding_box": bounding_box,
+                    },
+                }
+            ).encode()
+        elif url == dataset_url:
+            response._content = zip_content
+        else:
+            raise AssertionError(f"Unexpected outbound request: {url}")
+        return response
+
+    def mock_post(url, **kwargs):
+        assert url == "https://api.mobilitydatabase.org/v1/tokens"
+        response = requests.Response()
+        response.status_code = 200
+        response._content = json.dumps({"access_token": "mock_token"}).encode()
+        return response
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    monkeypatch.setattr(requests, "post", mock_post)
+    api = MobilityAPI(data_dir=tmp_path, refresh_token="mock_refresh_token")
+
+    with patch.object(api.logger, "info") as log_info:
+        dataset_path = api.download_latest_dataset("test-provider")
+
+    assert dataset_path is not None
+    metadata = api.list_downloaded_datasets()[0]
+    assert metadata.minimum_latitude == bounding_box["minimum_latitude"]
+    assert metadata.maximum_latitude == bounding_box["maximum_latitude"]
+    assert metadata.minimum_longitude == bounding_box["minimum_longitude"]
+    assert metadata.maximum_longitude == bounding_box["maximum_longitude"]
+
+    messages = [str(call.args[0]) for call in log_info.call_args_list]
+    assert "Using bounding box supplied by API/CSV" in messages
+    for value in bounding_box.values():
+        assert str(value) not in "\n".join(messages)
+
+
 def test_token_refresh_error():
     """Test handling of token refresh errors"""
     api = MobilityAPI(refresh_token="invalid_token")


### PR DESCRIPTION
## What changed

- keep public GTFS bounding-box values in dataset metadata
- replace the clear-text coordinate log with a source-only message
- add an end-to-end regression proving metadata is preserved and raw coordinate values are absent from logs

## Security analysis

CodeQL alert #17 treats feed bounds as private location data. These values describe public transit coverage and are already returned by the package, but copying them into logs is unnecessary. This removes that sink without changing download or metadata behavior.

## Validation

- focused logging and metadata regression passes
- Python compilation and git diff checks pass
- full GitHub Actions matrix and CodeQL run on the PR head